### PR TITLE
Changed asynchronous implementation for capability actions

### DIFF
--- a/definitions/capabilities.js
+++ b/definitions/capabilities.js
@@ -3,56 +3,56 @@ const SonyBraviaAndroidTvCommunicator = require('../helpers/sony-bravia-android-
 module.exports = [
   {
     name: 'onoff',
-    function: async (device, data, value) => {
+    function: (device, data, value) => {
       console.log(`${data.name} setting device power state to: `, value ? 'ON' : 'OFF');
 
-      return await SonyBraviaAndroidTvCommunicator.setDevicePowerState(device, data, value);
+      return SonyBraviaAndroidTvCommunicator.setDevicePowerState(device, data, value);
     }
   },
   {
     name: 'channel_up',
-    function: async (device, data, _value) => {
+    function: (device, data, _value) => {
       console.log(`${data.name} turning channel up.`);
 
-      return await SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'ChannelUp');
+      return SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'ChannelUp');
     }
   },
   {
     name: 'channel_down',
-    function: async (device, data, _value) => {
+    function: (device, data, _value) => {
       console.log(`${data.name} turning channel down.`);
 
-      return await SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'ChannelDown');
+      return SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'ChannelDown');
     }
   },
   {
     name: 'volume_up',
-    function: async (device, data, _value) => {
+    function: (device, data, _value) => {
       console.log(`${data.name} turning volume up.`);
 
-      return await SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'VolumeUp');
+      return SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'VolumeUp');
     }
   },
   {
     name: 'volume_down',
-    function: async (device, data, _value) => {
+    function: (device, data, _value) => {
       console.log(`${data.name} turning volume down.`);
 
-      return await SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'VolumeDown');
+      return SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'VolumeDown');
     }
   },
   {
     name: 'volume_mute',
-    function: async (device, data, value) => {
+    function: (device, data, value) => {
       if (value) {
         console.log(`${data.name} muting the sound.`);
 
-        return await SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'Mute');
+        return SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'Mute');
       }
 
       console.log(`${data.name} unmuting the sound.`);
 
-      return await SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'UnMute');
+      return SonyBraviaAndroidTvCommunicator.sendCommand(device, data, null, 'UnMute');
     }
   }
 ]

--- a/drivers/sony-bravia-android-tv/device.js
+++ b/drivers/sony-bravia-android-tv/device.js
@@ -72,11 +72,11 @@ class SonyBraviaAndroidTvDevice extends Homey.Device {
 
   async registerCapabilityListeners() {
     SonyBraviaCapabilities.forEach(capability => {
-      this.registerCapabilityListener(capability.name, value => {
+      this.registerCapabilityListener(capability.name, async value => {
         try {
           this.clearWarning();
 
-          capability.function(this, this.data, value);
+          return await capability.function(this, this.data, value);
         } catch (err) {
           this.showWarning(err);
 


### PR DESCRIPTION
### What changed?
This change should resolve timeout issues for capabilities. It should also resolve issues where Homey would not trigger `Turned on` and `Turned off` capability triggers directly.

### Related issues
These issues are related to this PR
- #7 
- #8 