### PR TITLE
Implemented setUnavailable errors

### DIFF
--- a/drivers/sony-bravia-android-tv/device.js
+++ b/drivers/sony-bravia-android-tv/device.js
@@ -165,7 +165,7 @@ class SonyBraviaAndroidTvDevice extends Homey.Device {
       return this.setUnavailable(Homey.__('errors.authentication'));
     }
 
-    return this.setUnavailable(Homey.__('errors.unknown'));
+    return this.setWarning(Homey.__('errors.unknown'));
   }
 }
 

--- a/drivers/sony-bravia-android-tv/device.js
+++ b/drivers/sony-bravia-android-tv/device.js
@@ -40,6 +40,8 @@ class SonyBraviaAndroidTvDevice extends Homey.Device {
       this.registerTasks();
     }
 
+    this.clearWarning();
+
     callback(null, newSettings);
   }
 
@@ -74,8 +76,6 @@ class SonyBraviaAndroidTvDevice extends Homey.Device {
     SonyBraviaCapabilities.forEach(capability => {
       this.registerCapabilityListener(capability.name, async value => {
         try {
-          this.clearWarning();
-
           return await capability.function(this, this.data, value);
         } catch (err) {
           this.showWarning(err);
@@ -93,8 +93,6 @@ class SonyBraviaAndroidTvDevice extends Homey.Device {
 
         flowCard.registerRunListener(async (args, state) => {
           try {
-            this.clearWarning();
-
             flow.parsedCommand = flow.command;
 
             if (flow.command instanceof Function) {
@@ -136,8 +134,6 @@ class SonyBraviaAndroidTvDevice extends Homey.Device {
   async checkDeviceAvailability() {
     try {
       await SonyBraviaAndroidTvCommunicator.getDeviceAvailability(this.data);
-
-      this.clearWarning();
       return this.setAvailable();
     } catch (err) {
       this.showWarning(err);
@@ -152,7 +148,6 @@ class SonyBraviaAndroidTvDevice extends Homey.Device {
 
       console.log(`${this.data.name} current power state: `, state);
 
-      this.clearWarning();
       return this.setCapabilityValue('onoff', state === 'active' ? true : false);
     } catch (err) {
       this.showWarning(err);
@@ -162,15 +157,15 @@ class SonyBraviaAndroidTvDevice extends Homey.Device {
   }
 
   clearWarning() {
-    return this.unsetWarning();
+    return this.setAvailable();
   }
 
   showWarning(err) {
     if (err.code === 403) {
-      return this.setWarning(Homey.__('errors.authentication'));
+      return this.setUnavailable(Homey.__('errors.authentication'));
     }
 
-    return this.setWarning(Homey.__('errors.unknown'));
+    return this.setUnavailable(Homey.__('errors.unknown'));
   }
 }
 

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,7 +1,7 @@
 {
   "errors": {
     "authentication": "Authentication failed, check pre-shared key settings.",
-    "unkown": "An unknown error occured, please try again.",
+    "unkown": "An unknown error occured, check television settings.",
     "connection": "Connection could not be estabished.",
     "preshared_key": "Pre-shared key is invalid, check television settings.",
     "previous_view": "Previous view could not be loaded."

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -1,7 +1,7 @@
 {
   "errors": {
     "authentication": "Authenticatie mislukt, controleer pre-shared key instelligen.",
-    "unkown": "Onbekede fout, probeer het nog eens.",
+    "unkown": "Onbekede fout, controleer televisie instellingen.",
     "connection": "Er kon geen verbinding worden gemaakt.",
     "preshared_key": "Pre-shared key is incorrect, controleer televisie instellingen.",
     "previous_view": "De vorige view kon niet worden geladen."


### PR DESCRIPTION
After authentication with the TV failed, user should be notified about this and the functions should be halted to unload Homey.

Instead of using `setWarning` which wasn't implemented in Homey yet (see #4), we now use `setUnavailable` to disable the TV usage until settings are changed.