### PR TITLE
SDK3 Device pairing rewrite

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,6 +4,7 @@
   "version": "1.0.4",
   "compatibility": ">=5.0.0",
   "sdk": 3,
+  "brandColor": "#000000",
   "name": {
     "en": "Sony BRAVIA Android TV"
   },

--- a/drivers/sony-bravia-android-tv/driver.js
+++ b/drivers/sony-bravia-android-tv/driver.js
@@ -3,48 +3,59 @@ const Homey = require('homey');
 const SonyBraviaAndroidTvFinder = require('../../helpers/sony-bravia-android-tv-finder');
 
 class SonyBraviaAndroidTvDriver extends Homey.Driver {
-  onPair(socket) {
-    socket.on('list_devices', (_devices, callback) => this.fetchAvailableDevices(callback, socket));
-    socket.on('manual_input', (data, callback) => this.fetchDeviceDetails(data, callback));
-    socket.on('preshared_key', (device, callback) => this.fetchExpandedDeviceDetails(device, callback));
+  onPair(session) {
+    session.setHandler('list_devices', async () => await this.fetchAvailableDevices(session));
+    session.setHandler('manual_input', async (data) => await this.fetchDeviceDetails(data));
+    session.setHandler('preshared_key', async (device) => await this.fetchExpandedDeviceDetails(device));
   }
 
   async fetchExpandedDeviceDetails(device, callback) {
     try {
-      const extendedDevice = await SonyBraviaAndroidTvFinder.fetchExtendDeviceDetails(device);
+      const extendedDevice =
+        await SonyBraviaAndroidTvFinder.fetchExtendDeviceDetails(device);
 
-      console.log('Got extended Sony BRAVIA Android TV data: ', extendedDevice);
+      this.log('Got extended Sony BRAVIA Android TV data: ', extendedDevice);
 
-      callback(null, extendedDevice);
+      return extendedDevice;
     } catch (err) {
-      callback(err, null);
+      this.err(err);
     }
+
+    return null;
   }
 
-  async fetchDeviceDetails(data, callback) {
-    const device = SonyBraviaAndroidTvFinder.populateDeviceData(data.name, null, data.ipAddress, data.macAddress);
+  async fetchDeviceDetails(data) {
+    const device = SonyBraviaAndroidTvFinder.populateDeviceData(
+      data.name,
+      null,
+      data.ipAddress,
+      data.macAddress
+    );
 
     try {
-      const basicDevice = await SonyBraviaAndroidTvFinder.fetchBasicDeviceDetails(device);
+      const basicDevice =
+        await SonyBraviaAndroidTvFinder.fetchBasicDeviceDetails(device);
 
-      console.log('Got basic Sony BRAVIA Android TV data: ', basicDevice);
+      this.log('Got basic Sony BRAVIA Android TV data: ', basicDevice);
 
-      callback(null, basicDevice);
+      return basicDevice;
     } catch (err) {
-      callback(err, null);
+      this.err(err);
     }
+
+    return null;
   }
 
-  async fetchAvailableDevices(callback, socket) {
+  async fetchAvailableDevices(session) {
     const devices = await SonyBraviaAndroidTvFinder.getAllDevices();
 
-    console.log('Found Sony BRAVIA Android TV\'s: ', devices);
+    this.log('Found Sony BRAVIA Android TV\'s: ', devices);
 
     if (devices.length < 1) {
-      socket.showView('not_found');
+      session.showView('not_found');
     }
 
-    callback(null, devices);
+    return devices;
   }
 }
 


### PR DESCRIPTION
Quick fix to allow searching and pairing new Bravia TVs.

Tested to work with 8.11

## Dependancies
Awaiting @oh2th's PR #22 to be merged